### PR TITLE
Adds contributors list

### DIFF
--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -66,9 +66,10 @@
     margin-right: 4vw;
 }
 
-.graduate-list {
+.graduate-list, .contributor-list {
     list-style-type: none;
-
+    margin-bottom: 1rem;
+    
     li {
         margin-bottom: 0.25rem;
     }
@@ -80,6 +81,10 @@ sup {
 
 .year-list-item-archivelinkcontainer {
     min-height: 2rem;
+}
+
+.contributor-list {
+    margin: 0 4vw;
 }
 
 ::-webkit-scrollbar {

--- a/index.html
+++ b/index.html
@@ -53,3 +53,13 @@ layout: default
         </ul>
     </div>
 </section>
+
+<section class="content">
+    <h2>Contributors  <sup>(4)</sup></h2>
+    <ul class="contributor-list">
+            <li>Chris Vitas — Archive Prep, 2009</li>
+            <li>Henry Wilkinson — Site Code</li>
+            <li>Theo Nguyen — Archive Prep, 2022</li>
+            <li>Zilin Deng — Site Code, Creator</li>
+        </ul>
+</section>

--- a/index.html
+++ b/index.html
@@ -57,9 +57,10 @@ layout: default
 <section class="content">
     <h2>Contributors  <sup>(4)</sup></h2>
     <ul class="contributor-list">
-        <li>Chris Vitas — Archive Prep, 2009</li>
+        <li>Archive Team — Archiving: 2020, 2021</li>
+        <li>Chris Vitas — Archive Prep: 2009</li>
         <li>Henry Wilkinson — Site Code</li>
-        <li>Theo Nguyen — Archive Prep, 2022</li>
-        <li>Zilin Deng — Site Code, Creator</li>
+        <li>Theo Nguyen — Archive Prep: 2022</li>
+        <li>Zilin Deng — Site Code: Creator</li>
         </ul>
 </section>

--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@ layout: default
 <section class="content">
     <h2>Contributors  <sup>(4)</sup></h2>
     <ul class="contributor-list">
-            <li>Chris Vitas — Archive Prep, 2009</li>
-            <li>Henry Wilkinson — Site Code</li>
-            <li>Theo Nguyen — Archive Prep, 2022</li>
-            <li>Zilin Deng — Site Code, Creator</li>
+        <li>Chris Vitas — Archive Prep, 2009</li>
+        <li>Henry Wilkinson — Site Code</li>
+        <li>Theo Nguyen — Archive Prep, 2022</li>
+        <li>Zilin Deng — Site Code, Creator</li>
         </ul>
 </section>


### PR DESCRIPTION
### Changes
- Adds list of the site's contributors with their name, what they contributed, and any specifics.  So far we're up to 4 people!  I had two folks help me prepare two of the sites for archiving and without them they would not function!
- Adds margin to the bottom of the grads list to ensure scroll bar doesn't overlap names

### Screenshots

<img width="809" alt="Screenshot 2023-08-08 at 1 07 20 AM" src="https://github.com/ysdn-info/ysdn.info/assets/5672810/be4a217e-8d0f-47ff-a2e5-25ca7b08f7eb">