### PR TITLE
Adds a supplementary material link slot per-year

### DIFF
--- a/_data/_years/2021.yaml
+++ b/_data/_years/2021.yaml
@@ -1,6 +1,8 @@
 year: 2021
 archivelink: "https://ysdn-info.s3.us-east-005.backblazeb2.com/ysdn2021.wacz"
 archivestarturl: "https://ysdn2021.com/"
+additionallink: "https://ysdn-info.s3.us-east-005.backblazeb2.com/ysdn2021_zine.pdf"
+additionallinktext: "Download Zine"
 archivepublished: true
 graduates:
     - "Alice Longtin"

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -59,6 +59,7 @@
     h3 {
         font-size: 1.75em;
         font-weight: 200;
+        margin-bottom: 0;
     }
 }
 
@@ -80,7 +81,12 @@ sup {
 }
 
 .year-list-item-archivelinkcontainer {
-    min-height: 2rem;
+    min-height: 3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
 }
 
 .contributor-list {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ layout: default
                         <a href="{{ year[1].additionallink }}" class="link">{{ year[1].additionallinktext }}</a>
                         {% endif %}
                         {% if archivepublished == true %}
-                        <a href="archives/{{ year[1].year }}" class="link">View Gradshow</a>
+                        <a href="archives/{{ year[1].year }}" class="link">View Grad Show</a>
                         {% endif %}
                     </div>
                     <ul class="graduate-list">

--- a/index.html
+++ b/index.html
@@ -29,10 +29,15 @@ layout: default
             {% for year in site.data._years reversed %}
             {% assign graduates = year[1].graduates %}
             {% assign archivepublished = year[1].archivepublished %}
+            {% assign additionallink = year[1].additionallink %}
+            {% assign additionallink = year[1].additionallinktext %}
                 {% if graduates %}
                 <li class="year-list-item">
                     <h3><time datetime="{{ year[1].year }}">{{ year[1].year }} </time><sup>({{ year[1].graduates | size }})</sup></h3>
                     <div class="year-list-item-archivelinkcontainer">
+                        {% if additionallink %}
+                        <a href="{{ year[1].additionallink }}" class="link">{{ year[1].additionallinktext }}</a>
+                        {% endif %}
                         {% if archivepublished == true %}
                         <a href="archives/{{ year[1].year }}" class="link">View Gradshow</a>
                         {% endif %}


### PR DESCRIPTION
Spacing is kept the same as the current site

### Changes
- Adds a second link slot for each year for supplementary material
  - 2021 has a zine
  - 2017 has a book
- Adds zine link to 2021 data file

### Screenshots

**Before**
<img width="1760" alt="Screenshot 2023-08-11 at 3 33 59 PM" src="https://github.com/ysdn-info/ysdn.info/assets/5672810/088edba2-3fb8-4849-9abc-677142ec1840">


**After**
<img width="1481" alt="Screenshot 2023-08-11 at 3 29 55 PM" src="https://github.com/ysdn-info/ysdn.info/assets/5672810/ab21a5f5-9bbb-4497-9413-15ed0cd61fe2">
