### PR TITLE
Adds 2017 book

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,9 +11,9 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.4-arm64-darwin)
-    google-protobuf (3.23.4-x86_64-darwin)
-    google-protobuf (3.23.4-x86_64-linux)
+    google-protobuf (3.24.3-arm64-darwin)
+    google-protobuf (3.24.3-x86_64-darwin)
+    google-protobuf (3.24.3-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -59,7 +59,7 @@ GEM
     rexml (3.2.6)
     rouge (4.1.3)
     safe_yaml (1.0.5)
-    sass-embedded (1.64.2)
+    sass-embedded (1.66.1)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
     terminal-table (3.0.2)
@@ -82,4 +82,4 @@ DEPENDENCIES
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.2.22
+   2.4.19

--- a/_data/_years/2017.yaml
+++ b/_data/_years/2017.yaml
@@ -1,5 +1,7 @@
 year: 2017
 archivepublished: false
+additionallink: "https://ysdn-info.s3.us-east-005.backblazeb2.com/ysdn2017_book.pdf"
+additionallinktext: "Download Book"
 graduates:
     - "Aline Nguyen"
     - "Allen Sung Kang"

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -65,6 +65,10 @@
 
 .year-list-final-item {
     margin-right: 4vw;
+
+    p {
+        margin-top: 3.75rem;
+    }
 }
 
 .graduate-list, .contributor-list {

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -87,6 +87,14 @@ sup {
     justify-content: flex-end;
     gap: 0.25rem;
     margin-bottom: 0.75rem;
+
+    a {
+        height: 1.125rem;
+    }
+}
+
+.year-list-item-archivelinkspacer {
+    height: 1.125rem;
 }
 
 .contributor-list {

--- a/index.html
+++ b/index.html
@@ -37,6 +37,9 @@ layout: default
                     <div class="year-list-item-archivelinkcontainer">
                         {% if additionallink %}
                         <a href="{{ year[1].additionallink }}" class="link">{{ year[1].additionallinktext }}</a>
+                        {% if archivepublished == false %}
+                        <div class="year-list-item-archivelinkspacer"></div>
+                        {% endif %}
                         {% endif %}
                         {% if archivepublished == true %}
                         <a href="archives/{{ year[1].year }}" class="link">View Grad Show</a>


### PR DESCRIPTION
Thanks to @rosszurowski we now have a copy of the 2017 grad show book!  This has been uploaded to Backblaze.  This PR adds a link to it

### Other changes

- Adds a div if there's an additional link for the year but no archived site.  This ensures the additional links and archived sites will always been in-line with each other
- Updates site dependencies, fixes deprecation warning in the command line (technical fix)
- Adds extra margin on the final item paragraph to bring it in-line with the list of names

### Screenshots

<img width="1106" alt="Screenshot 2023-09-08 at 3 34 36 PM" src="https://github.com/ysdn-info/ysdn.info/assets/5672810/d973f494-08fa-4aac-8659-12bc0693beaf">

<img width="701" alt="Screenshot 2023-09-08 at 3 44 47 PM" src="https://github.com/ysdn-info/ysdn.info/assets/5672810/e31d2db5-fbfe-4cca-8ca8-14c0e3a19f20">

